### PR TITLE
Use EXPECT instead of EXPECTF when possible

### DIFF
--- a/tests/007.phpt
+++ b/tests/007.phpt
@@ -3,7 +3,7 @@ FFI 007: Pointer comparison
 --SKIPIF--
 <?php require_once('skipif.inc'); ?>
 --FILE--
-<?php 
+<?php
 $v = FFI::new("int*[3]");
 $v[0] = FFI::new("int", false);
 $v[1] = FFI::new("int", false);
@@ -14,6 +14,6 @@ var_dump($v[1] == $v[2]);
 FFI::free($v[0]);
 FFI::free($v[1]);
 ?>
---EXPECTF--
+--EXPECT--
 bool(false)
 bool(true)

--- a/tests/008.phpt
+++ b/tests/008.phpt
@@ -27,7 +27,7 @@ try {
 	echo get_class($e) . ": " . $e->getMessage()."\n";
 }
 ?>
---EXPECTF--
+--EXPECT--
 int(3)
 0 => 0
 1 => 10

--- a/tests/012.phpt
+++ b/tests/012.phpt
@@ -10,5 +10,5 @@ try {
 	echo get_class($e) . ": " . $e->getMessage()."\n";
 }
 ?>
---EXPECTF--
+--EXPECT--
 Exception: Serialization of 'FFI\CData' is not allowed

--- a/tests/013.phpt
+++ b/tests/013.phpt
@@ -51,7 +51,7 @@ try {
 	echo get_class($e) . ": " . $e->getMessage()."\n";
 }
 ?>
---EXPECTF--
+--EXPECT--
 int(1)
 int(2)
 int(3)

--- a/tests/016.phpt
+++ b/tests/016.phpt
@@ -24,7 +24,7 @@ try {
 }
 ?>
 ok
---EXPECTF--
+--EXPECT--
 FFI\ParserException: 'function' type is not allowed at line 1
 FFI\ParserException: struct/union can't contain an instance of itself at line 1
 ok

--- a/tests/018.phpt
+++ b/tests/018.phpt
@@ -18,7 +18,7 @@ try {
 }
 ?>
 ok
---EXPECTF--
+--EXPECT--
 FFI\ParserException: incomplete 'struct X' at line 1
 ok
 ok

--- a/tests/019.phpt
+++ b/tests/019.phpt
@@ -18,7 +18,7 @@ try {
 }
 ?>
 ok
---EXPECTF--
+--EXPECT--
 ok
 ok
 ok

--- a/tests/020.phpt
+++ b/tests/020.phpt
@@ -58,7 +58,7 @@ try {
 }
 ?>
 ok
---EXPECTF--
+--EXPECT--
 FFI\Exception: Attempt to assign read-only field 'y'
 FFI\Exception: Attempt to assign read-only field 'x'
 FFI\Exception: Attempt to assign read-only location

--- a/tests/027.phpt
+++ b/tests/027.phpt
@@ -74,7 +74,7 @@ try {
 	echo get_class($e) . ": " . $e->getMessage()."\n";
 }
 ?>
---EXPECTF--
+--EXPECT--
 FFI\ParserException: '[*]' not allowed in other than function prototype scope at line 1
 FFI\ParserException: '[*]' not allowed in other than function prototype scope at line 1
 FFI\ParserException: '[*]' not allowed in other than function prototype scope at line 1


### PR DESCRIPTION
Inspired by https://github.com/php/php-src/pull/3133, where I explained that we should avoid `EXPECTF` when possible as it is a slower section than `EXPECT` :)