### PR TITLE
Remove unused Git attributes ident

### DIFF
--- a/config.m4
+++ b/config.m4
@@ -1,4 +1,3 @@
-dnl $Id$
 dnl config.m4 for extension FFI
 
 PHP_ARG_WITH(ffi, for FFI support,


### PR DESCRIPTION
Hello,

The `$Id$` keywords were used in Subversion where they can be substituted with filename, last revision number change, last changed date, and last user who changed it.

In Git this functionality is different and can be done with Git attribute ident. These need to be defined manually for each file in the `.gitattributes` file and are afterwards replaced with 40-character hexadecimal blob object name which is based only on the particular file contents.

This patch simplifies handling of `$Id$` keywords by removing them since they are not used anymore.

Thanks for considering merging this or checking it out.