### PR TITLE
Use pkg-config to locate libffi

### DIFF
--- a/config.m4
+++ b/config.m4
@@ -5,34 +5,52 @@ PHP_ARG_WITH(ffi, for FFI support,
 
 if test "$PHP_FFI" != "no"; then
   if test -r $PHP_FFI/include/ffi.h; then
-    FFI_DIR=$PHP_FFI
+    FFI_INCDIR=$PHP_FFI/include
+    FFI_LIBDIR=$PHP_FFI
   else
-    AC_MSG_CHECKING(for libffi in default path)
-    for i in /usr/local /usr; do
-      if test -r $i/include/ffi.h; then
-        FFI_DIR=$i
-        AC_MSG_RESULT(found in $i)
-        break
-      fi
-    done
-  fi
+    dnl First try to find pkg-config
+    if test -z "$PKG_CONFIG"; then
+      AC_PATH_PROG(PKG_CONFIG, pkg-config, no)
+    fi
 
-  if test -z "$FFI_DIR"; then
-    AC_MSG_RESULT(not found)
-    AC_MSG_ERROR(Please reinstall the libffi distribution)
+    dnl If pkg-config is installed, try using it
+    if test -x "$PKG_CONFIG" && "$PKG_CONFIG" --exists libffi; then
+      FFI_VER=`"$PKG_CONFIG" --modversion libffi`
+      FFI_INCDIR=`"$PKG_CONFIG" --variable=includedir libffi`
+      FFI_LIBDIR=`"$PKG_CONFIG" --variable=libdir libffi`
+      AC_MSG_CHECKING(for libffi)
+      AC_MSG_RESULT(found version $FFI_VER)
+    else
+      AC_MSG_CHECKING(for libffi in default path)
+      for i in /usr/local /usr; do
+        if test -r $i/include/ffi.h; then
+          FFI_DIR=$i
+          AC_MSG_RESULT(found in $i)
+          break
+        fi
+      done
+
+      if test -z "$FFI_DIR"; then
+        AC_MSG_RESULT(not found)
+        AC_MSG_ERROR(Please reinstall the libffi distribution)
+      fi
+
+      FFI_INCDIR="$FFI_DIR/include"
+      FFI_LIBDIR="$FFI_DIR/$PHP_LIBDIR"
+    fi
   fi
 
   AC_CHECK_TYPES(long double)
 
   PHP_CHECK_LIBRARY(ffi, ffi_call, 
   [
-    PHP_ADD_INCLUDE($FFI_DIR/include)
-    PHP_ADD_LIBRARY_WITH_PATH(ffi, $FFI_DIR/$PHP_LIBDIR, FFI_SHARED_LIBADD)
+    PHP_ADD_INCLUDE($FFI_INCDIR)
+    PHP_ADD_LIBRARY_WITH_PATH(ffi, $FFI_LIBDIR, FFI_SHARED_LIBADD)
     AC_DEFINE(HAVE_FFI,1,[ Have ffi support ])
   ], [
     AC_MSG_ERROR(FFI module requires libffi)
   ], [
-    -L$FFI_DIR/$PHP_LIBDIR
+    -L$FFI_LIBDIR
   ])
 
   PHP_NEW_EXTENSION(ffi, ffi.c ffi_parser.c, $ext_shared)


### PR DESCRIPTION
This makes ./configure use pkg-config whenever possible to locate libffi.

This is especially important on Linux distributions where libffi-dev is distributed as a multi-arch package (eg. Debian >= oldoldstable, Ubuntu >= 14.04 LTS) because the headers get installed into ``/usr/include/x86_64-linux-gnu/`` and the current config.m4 does not pick them up automatically.