### PR TITLE
Windows test fixes

### DIFF
--- a/ffi.c
+++ b/ffi.c
@@ -2541,7 +2541,7 @@ ZEND_METHOD(FFI, cdef) /* {{{ */
 	zend_string *code = NULL;
 	zend_string *lib = NULL;
 	zend_ffi *ffi = NULL;
-	DL_HANDLE handle;
+	DL_HANDLE handle = NULL;
 	void *addr;
 
 	ZEND_FFI_VALIDATE_API_RESTRICTION();

--- a/tests/022.phpt
+++ b/tests/022.phpt
@@ -60,8 +60,10 @@ test_align(4, "struct  {char a; uint32_t b __attribute__((aligned(1)));}");
 test_size(32, "struct {char a; uint32_t b __attribute__((aligned(16)));}");
 test_align(16, "struct {char a; uint32_t b __attribute__((aligned(16)));}");
 
-test_size(32, "struct  {char a; uint32_t b __attribute__((aligned));}");
-test_align(16, "struct  {char a; uint32_t b __attribute__((aligned));}");
+if (substr(PHP_OS, 0, 3) != 'WIN') {
+	test_size(32, "struct  {char a; uint32_t b __attribute__((aligned));}");
+	test_align(16, "struct  {char a; uint32_t b __attribute__((aligned));}");
+}
 ?>
 ok
 --EXPECT--

--- a/tests/300-win32.h.in
+++ b/tests/300-win32.h.in
@@ -1,0 +1,4 @@
+#define FFI_SCOPE "TEST_300_WIN32"
+#define FFI_LIB "PHP_DLL_NAME"
+
+size_t php_printf(const char *format, ...);

--- a/tests/300-win32.phpt
+++ b/tests/300-win32.phpt
@@ -1,21 +1,18 @@
 --TEST--
-FFI 301: FFI loading on Windows
+FFI 300: FFI preloading on Windows
 --SKIPIF--
 <?php require_once('skipif.inc'); ?>
+<?php if (!extension_loaded('Zend OPcache')) die('skip Zend OPcache extension not available'); ?>
 <?php if (substr(PHP_OS, 0, 3) != 'WIN') die('skip for Windows only'); ?>
 --INI--
 ffi.enable=1
+opcache.enable=1
+opcache.enable_cli=1
+opcache.optimization_level=-1
+opcache.preload={PWD}/preload.inc
 --FILE--
 <?php
-$fn = __DIR__ . "/300-win32.h";
-$cont = str_replace(
-		"PHP_DLL_NAME",
-		"php" . PHP_MAJOR_VERSION . (PHP_ZTS ? "ts" : "") . ".dll",
-		file_get_contents("$fn.in")
-	);
-file_put_contents($fn, $cont);
-
-$ffi = FFI::load($fn);
+$ffi = FFI::scope("TEST_300_WIN32");
 $ffi->php_printf("Hello World from %s!\n", "PHP");
 ?>
 --CLEAN--

--- a/tests/300.phpt
+++ b/tests/300.phpt
@@ -3,6 +3,7 @@ FFI 300: FFI preloading
 --SKIPIF--
 <?php require_once('skipif.inc'); ?>
 <?php if (!extension_loaded('Zend OPcache')) die('skip Zend OPcache extension not available'); ?>
+<?php if (substr(PHP_OS, 0, 3) == 'WIN') die('skip not for Windows'); ?>
 --INI--
 ffi.enable=1
 opcache.enable=1

--- a/tests/301-win32.phpt
+++ b/tests/301-win32.phpt
@@ -1,0 +1,27 @@
+--TEST--
+FFI 301: FFI loading
+--SKIPIF--
+<?php require_once('skipif.inc'); ?>
+<?php if (substr(PHP_OS, 0, 3) != 'WIN') die('skip for Windows only'); ?>
+--INI--
+ffi.enable=1
+--FILE--
+<?php
+$fn = __DIR__ . "/300-win32.h";
+$cont = str_replace(
+		"PHP_DLL_NAME",
+		"php" . PHP_MAJOR_VERSION . (PHP_ZTS ? "ts" : "") . ".dll",
+		file_get_contents("$fn.in")
+	);
+file_put_contents($fn, $cont);
+
+$ffi = FFI::load($fn);
+$ffi->php_printf("Hello World from %s!\n", "PHP");
+?>
+--CLEAN--
+<?php
+	$fn = __DIR__ . "/300-win32.h";
+	unlink($fn);
+?>
+--EXPECT--
+Hello World from PHP!

--- a/tests/301-win32.phpt
+++ b/tests/301-win32.phpt
@@ -10,7 +10,7 @@ ffi.enable=1
 $fn = __DIR__ . "/300-win32.h";
 $cont = str_replace(
 		"PHP_DLL_NAME",
-		"php" . PHP_MAJOR_VERSION . (PHP_ZTS ? "ts" : "") . ".dll",
+		"php" . PHP_MAJOR_VERSION . (PHP_ZTS ? "ts" : "") . (PHP_DEBUG ? "_debug" : "") . ".dll",
 		file_get_contents("$fn.in")
 	);
 file_put_contents($fn, $cont);

--- a/tests/301.phpt
+++ b/tests/301.phpt
@@ -2,6 +2,7 @@
 FFI 301: FFI loading
 --SKIPIF--
 <?php require_once('skipif.inc'); ?>
+<?php if (substr(PHP_OS, 0, 3) == 'WIN') die('skip not for Windows'); ?>
 --INI--
 ffi.enable=1
 --FILE--

--- a/tests/preload.inc
+++ b/tests/preload.inc
@@ -1,2 +1,14 @@
 <?php
-FFI::load(__DIR__ . "/300.h");
+if (substr(PHP_OS, 0, 3) == 'WIN') { 
+	$fn = __DIR__ . "/300-win32.h";
+	$cont = str_replace(
+			"PHP_DLL_NAME",
+			"php" . PHP_MAJOR_VERSION . (PHP_ZTS ? "ts" : "") . ".dll",
+			file_get_contents("$fn.in")
+		);
+	file_put_contents($fn, $cont);
+	$ffi = FFI::load($fn);
+	/* Test should cleanup this. */
+} else {
+	FFI::load(__DIR__ . "/300.h");
+}

--- a/tests/preload.inc
+++ b/tests/preload.inc
@@ -3,7 +3,7 @@ if (substr(PHP_OS, 0, 3) == 'WIN') {
 	$fn = __DIR__ . "/300-win32.h";
 	$cont = str_replace(
 			"PHP_DLL_NAME",
-			"php" . PHP_MAJOR_VERSION . (PHP_ZTS ? "ts" : "") . ".dll",
+			"php" . PHP_MAJOR_VERSION . (PHP_ZTS ? "ts" : "") . (PHP_DEBUG ? "_debug" : "") . ".dll",
 			file_get_contents("$fn.in")
 		);
 	file_put_contents($fn, $cont);


### PR DESCRIPTION
Except one uninitialized var fix, the most things done are test fixes.

- 300.phpt and 301.phpt has been forked to use `php_printf`, as `printf` is not an exported symbol in the latest C runtimes anymore
- those tests also use explicit DLL filenames
- 022.phpt seems to work with `__attribute__` after all, as in the end it's parsed by the extension, not a compiler. The only change here is the need to provide an explicit alignment. It might hang together with the absense of `__BIGGEST_ALIGNMENT__`, so for now it's set to `sizeof(size_t)`. The doc states, that for alignment `Valid entries are integer powers of two from 1 to 8192`, https://docs.microsoft.com/en-us/previous-versions/83ythb65(v=vs.140).

As from the above link, `__declspec(align(#))` requires an explicit alignment. With an explicit alignment, the behavior as expected and is identical to what the compiler does. Like a sample program here
```
#include <stdio.h>
#include <inttypes.h>

/* Same what is currently possible with PHP as
struct { char a; uint32_t b __attribute__((aligned(16))); }
*/
struct hello { char a; __declspec(align(16)) uint32_t b; };

int
main(int argc, char **argv)
{
        printf("sizeof(struct hello) = %zu\n", sizeof(struct hello));
        printf("alignof(struct hello) = %zu\n", __alignof(struct hello));
        return 0;
}

/* Produce
sizeof(struct hello) = 32
alignof(struct hello) = 16
*/
```

As the form of `__attribute__((aligned))` parsed by the extension and doesn't require any compiler, this seems to be ok also on Windows. Nevertheless `__declspec` could be considered to be handled as well. At least the visibility variant is supported by GCC https://gcc.gnu.org/wiki/Visibility, but not sure visibility can be actually handled by libffi. All in all, this PR eliminates the remaining test fails, further handling might be improved when it comes to a wider usage later. 

Thanks.