### PR TITLE
Allow to fetch function address

### DIFF
--- a/ffi.c
+++ b/ffi.c
@@ -2066,7 +2066,7 @@ static zval *zend_ffi_read_var(zval *object, zval *member, int read_type, void *
 
 	if (ffi->symbols) {
 		sym = zend_hash_find_ptr(ffi->symbols, var_name);
-		if (sym && sym->kind != ZEND_FFI_SYM_VAR && sym->kind != ZEND_FFI_SYM_CONST) {
+		if (sym && sym->kind != ZEND_FFI_SYM_VAR && sym->kind != ZEND_FFI_SYM_CONST && sym->kind != ZEND_FFI_SYM_FUNC) {
 			sym = NULL;
 		}
 	}


### PR DESCRIPTION
allow to fetch a function address, this is useful when we try to pass a C function as a callback to another C function 